### PR TITLE
Autoriser la création de reçus "abandon_frais"

### DIFF
--- a/recus_fiscaux/nouveau.html
+++ b/recus_fiscaux/nouveau.html
@@ -53,7 +53,7 @@
 			montant_numeraire=$_POST.montant_numeraire|money_int}}
 		{{:assign total="%d+%d"|math:$montant_numeraire:$montant_nature}}
 	{{else}}
-		{{if !$_POST.numeraire && !$_POST.nature}}
+		{{if !$_POST.numeraire && !$_POST.abandon_frais && !$_POST.nature}}
 			{{:error message="Le type de don n'a pas été sélectionné."}}
 		{{elseif $_POST.numeraire && !$_POST.moyens_especes && !$_POST.moyens_cheques && !$_POST.moyens_autres}}
 			{{:error message="Aucun moyen de paiement n'a été coché."}}


### PR DESCRIPTION
![image](https://github.com/kd2org/paheko-modules/assets/29739547/308f3ed9-a050-4261-aee7-4637147e8e1c)

L'erreur "Le type de don n'a pas été sélectionnée" se déclenche quand le type "Abandon de frais" est selectionné. Cette pull request corrige ce problème.
Je ne sais pas utiliser Fossil alors j'utilise Git :sweat_smile: 