### PR TITLE
libelle plus neutre

### DIFF
--- a/web/_head.html
+++ b/web/_head.html
@@ -91,7 +91,7 @@
 {{if $module.config.show_bookings !== false}}
 	{{#module name="bookings"}}
 		<p class="booking-btn">
-			<a href="{{$public_url}}" target="_blank"><span></span><b>Réserver un créneau</b></a>
+			<a href="{{$public_url}}" target="_blank"><span></span><b>Réserver</b></a>
 		</p>
 	{{/module}}
 {{/if}}


### PR DESCRIPTION
"Réserver un créneau" ne se prête pas au cas d'usage de notre association, qui organise des événements mensuels à une heure bien précise.
"**Réserver**" permet de ne pas induire les utilisateurs en erreur tout en restant limpide pour les autres cas d'usages